### PR TITLE
Use remix-auth-oauth2 v2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@speechmatics/remix-auth-microsoft",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@speechmatics/remix-auth-microsoft",
-      "version": "2.0.1",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "remix-auth": "^3.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
-  "name": "remix-auth-microsoft",
+  "name": "@speechmatics/remix-auth-microsoft",
   "version": "2.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "remix-auth-microsoft",
+      "name": "@speechmatics/remix-auth-microsoft",
       "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "remix-auth": "^3.6.0",
-        "remix-auth-oauth2": "^1.11.0"
+        "remix-auth-oauth2": "^2.0.0"
       },
       "devDependencies": {
         "@babel/core": "^7.14.2",
@@ -2649,11 +2649,38 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@oslojs/binary": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@oslojs/binary/-/binary-0.2.0.tgz",
+      "integrity": "sha512-ubZRUsR675TzsccCQADGtPlKgNMCFkmhZ8FXgStxd5nMjrqNgVKhVtpKks6jCOap+U6Ny+yib8S/It2Cu8zVZQ=="
+    },
+    "node_modules/@oslojs/crypto": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@oslojs/crypto/-/crypto-0.2.0.tgz",
+      "integrity": "sha512-C6kM0Yg2r0xWm7XoxAAdEaM/96yZbPRe8aCFfDenpl9VF3K3VOghRexrY4h812BRm3oRWesucBkYNlnliDv2LA==",
+      "dependencies": {
+        "@oslojs/binary": "0.2.0"
+      }
+    },
+    "node_modules/@oslojs/encoding": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-0.2.0.tgz",
+      "integrity": "sha512-Z3AjpTFBsAiJBYl88fFRkjRWNgpu5PNqwWupfxyyqMFAoed+i2uIbMxQZr7AKhEy7ARclDxVRb/OkkBlO5qkhw=="
+    },
+    "node_modules/@oslojs/oauth2": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@oslojs/oauth2/-/oauth2-0.1.0.tgz",
+      "integrity": "sha512-3pdqKcqRFCXLw6QyLrlsgDoEJGbjzj5WsBkqJfdyQhLFku6vZUK8TArhMQhtMPyCSKJiPWC3C5Ma98XphJY8uQ==",
+      "dependencies": {
+        "@oslojs/crypto": "0.2.0",
+        "@oslojs/encoding": "0.2.0"
+      }
+    },
     "node_modules/@remix-run/node": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@remix-run/node/-/node-1.1.1.tgz",
       "integrity": "sha512-8WhpjiDqHb+RpsN95vygYrxyui/dWKi9ECJju+/xBuP8pODRKXU9hrCoxVC2FjFRhXUdErkCEDK/AZSDPAlqVw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@remix-run/server-runtime": "1.1.1",
         "@types/busboy": "^0.3.1",
@@ -2672,7 +2699,7 @@
       "version": "0.7.3",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
       "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">= 8"
       }
@@ -2797,7 +2824,7 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/@types/busboy/-/busboy-0.3.1.tgz",
       "integrity": "sha512-8BPLNy4x+7lbTOGkAyUIZrrPEZ7WzbO7YlVGMf9EZi9J9mqILEkYbt/kgVWQ7fizOISo1hM/7cAsWVTa7EhQDg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -2860,13 +2887,13 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.2.tgz",
       "integrity": "sha512-JepeIUPFDARgIs0zD/SKPgFsJEAF0X5/qO80llx59gOxFTboS9Amv3S+QfB7lqBId5sFXJ99BN0J6zFRvL9dDA==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/node-fetch": {
       "version": "2.5.12",
       "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.12.tgz",
       "integrity": "sha512-MKgC4dlq4kKNa/mYrwpKfzQMB5X3ee5U6fSprkKpToBqBmX4nFZL9cW5jl6sWn+xpRJ7ypWh2yyqqr8UUCstSw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/node": "*",
         "form-data": "^3.0.0"
@@ -2876,7 +2903,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
       "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -3169,7 +3196,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@web-std/blob/-/blob-3.0.1.tgz",
       "integrity": "sha512-opuhO8ZGGUj2jdFwfgMjWjVdKaHlQanGWXxj5wV2YQ1uGTuL/SADnsDitpMfRb+lSpmQyzpwZFfj4CNKQuwSKQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@web-std/stream": "1.0.0",
         "web-encoding": "1.1.5"
@@ -3179,7 +3206,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@web-std/file/-/file-3.0.0.tgz",
       "integrity": "sha512-ac2H3IUOky3GRJdbdJYgVvH+OApzpr0KX0t9p6Nj9AuHxKudc0pD7mVruekCW4CZv6DbOReDukwwskJN1bSCzA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@web-std/blob": "^3.0.0"
       }
@@ -3188,7 +3215,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@web-std/stream/-/stream-1.0.0.tgz",
       "integrity": "sha512-jyIbdVl+0ZJyKGTV0Ohb9E6UnxP+t7ZzX4Do3AHjZKxUXKMs9EmqnBDQgHF7bEw0EzbQygOjtt/7gvtmi//iCQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "web-streams-polyfill": "^3.1.1"
       }
@@ -3210,7 +3237,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
       "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "event-target-shim": "^5.0.0"
       },
@@ -3408,7 +3435,7 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/atob": {
       "version": "2.1.2",
@@ -3426,7 +3453,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
       "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -3684,13 +3711,13 @@
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
       "integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/blob-stream": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/blob-stream/-/blob-stream-0.1.3.tgz",
       "integrity": "sha1-mNZor2mW4PMu9mbQbiFczH13aGw=",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "blob": "0.0.4"
       }
@@ -3777,7 +3804,7 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.3.1.tgz",
       "integrity": "sha512-y7tTxhGKXcyBxRKAni+awqx8uqaJKrSFSNFSeRG5CsWNdmy2BIK+6VGWEW7TZnIO/533mtMEA4rOevQV815YJw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "dicer": "0.3.0"
       },
@@ -3809,7 +3836,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
       "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
@@ -4071,7 +4098,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -4112,7 +4139,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.1.0.tgz",
       "integrity": "sha512-Alvs19Vgq07eunykd3Xy2jF0/qSNv2u7KDbAek9H5liV1UMijbqFs5cycZvv5dVsvseT/U4H8/7/w8Koh35C4A==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=6.6.0"
       }
@@ -4319,7 +4346,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "object-keys": "^1.0.12"
       },
@@ -4344,7 +4371,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -4362,7 +4389,7 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.3.0.tgz",
       "integrity": "sha512-MdceRRWqltEG2dZqO769g27N/3PXfcKl04VhYnBlo2YhH7zPi88VebsjTKclaOyiuMaGU72hTfw3VkUitGcVCA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "streamsearch": "0.1.2"
       },
@@ -4479,7 +4506,7 @@
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
       "integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
@@ -4513,7 +4540,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
       "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
@@ -5284,7 +5311,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=6"
       }
@@ -5718,13 +5745,13 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
       "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/form-data": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -5770,7 +5797,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
@@ -5794,7 +5821,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
       "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -5832,7 +5859,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
       "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.1.1"
@@ -5937,7 +5964,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "function-bind": "^1.1.1"
       },
@@ -5949,7 +5976,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
       "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
-      "dev": true,
+      "devOptional": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -5967,7 +5994,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
       "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -5979,7 +6006,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
       "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "has-symbols": "^1.0.2"
       },
@@ -6215,13 +6242,13 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/internal-slot": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
       "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "get-intrinsic": "^1.1.0",
         "has": "^1.0.3",
@@ -6247,7 +6274,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
       "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -6269,7 +6296,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
       "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "has-bigints": "^1.0.1"
       },
@@ -6281,7 +6308,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
       "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -6318,7 +6345,7 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
       "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -6372,7 +6399,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
       "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "has-tostringtag": "^1.0.0"
       },
@@ -6456,7 +6483,7 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
       "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "has-tostringtag": "^1.0.0"
       },
@@ -6483,7 +6510,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
       "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -6504,7 +6531,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.6.tgz",
       "integrity": "sha512-bEVOqiRcvo3zO1+G2lVMy+gkkEm9Yh7cDMRusKKu5ZJKPUYSJwICTKZrNKHA2EbSP0Tu0+6B/emsYNHZyn6K8g==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "has-tostringtag": "^1.0.0"
       },
@@ -6546,7 +6573,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
       "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -6562,7 +6589,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz",
       "integrity": "sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA==",
-      "dev": true,
+      "devOptional": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -6583,7 +6610,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
       "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "has-tostringtag": "^1.0.0"
       },
@@ -6598,7 +6625,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
       "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "has-symbols": "^1.0.2"
       },
@@ -6613,7 +6640,7 @@
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.8.tgz",
       "integrity": "sha512-HqH41TNZq2fgtGT8WHVFVJhBVGuY3AnP3Q36K8JKXUxSxRgk/d+7NjmwG2vo2mYmXK8UYZKu0qH8bVP5gEisjA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
@@ -6638,7 +6665,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
       "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "call-bind": "^1.0.2"
       },
@@ -8715,7 +8742,7 @@
       "version": "1.51.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
       "integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -8724,7 +8751,7 @@
       "version": "2.1.34",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
       "integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "mime-db": "1.51.0"
       },
@@ -8824,7 +8851,7 @@
       "version": "2.6.6",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
       "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -9012,7 +9039,7 @@
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
       "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
-      "dev": true,
+      "devOptional": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -9021,7 +9048,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -9042,7 +9069,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
       "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "call-bind": "^1.0.0",
         "define-properties": "^1.1.3",
@@ -9679,15 +9706,35 @@
       }
     },
     "node_modules/remix-auth-oauth2": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/remix-auth-oauth2/-/remix-auth-oauth2-1.11.0.tgz",
-      "integrity": "sha512-Yf1LF6NLYPFa7X2Rax/VEhXmYXFjZOi/q+7DmbMeoMHjAfkpqxbvzqqYSKIKDGR51z5TXR5na4to4380mir5bg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/remix-auth-oauth2/-/remix-auth-oauth2-2.0.0.tgz",
+      "integrity": "sha512-VCSaOkFs9hxaSDvTsscthvH1ZLXKXokOmfDUQF+90faeWclcdqKd79V5FLieNxKON6AXQhJn+wBNY4TWTaAe1g==",
+      "funding": [
+        "https://github.com/sponsors/sergiodxa"
+      ],
       "dependencies": {
+        "@oslojs/oauth2": "^0.1.0",
         "debug": "^4.3.4"
       },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=20.0.0"
+      },
       "peerDependencies": {
-        "@remix-run/server-runtime": "^1.0.0 || ^2.0.0",
+        "@remix-run/cloudflare": "^1.0.0 || ^2.0.0",
+        "@remix-run/deno": "^1.0.0 || ^2.0.0",
+        "@remix-run/node": "^1.0.0 || ^2.0.0",
         "remix-auth": "^3.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/cloudflare": {
+          "optional": true
+        },
+        "@remix-run/deno": {
+          "optional": true
+        },
+        "@remix-run/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/remove-trailing-separator": {
@@ -9849,7 +9896,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -10260,7 +10307,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
       "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "call-bind": "^1.0.0",
         "get-intrinsic": "^1.0.2",
@@ -10697,7 +10744,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
       "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo=",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -10733,7 +10780,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
       "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
@@ -10746,7 +10793,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
       "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
@@ -11005,7 +11052,7 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/ts-api-utils": {
       "version": "1.0.3",
@@ -11125,7 +11172,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
       "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "function-bind": "^1.1.1",
         "has-bigints": "^1.0.1",
@@ -11286,7 +11333,7 @@
       "version": "0.12.4",
       "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
       "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "is-arguments": "^1.0.4",
@@ -11371,7 +11418,7 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.1.5.tgz",
       "integrity": "sha512-HYLeVCdJ0+lBYV2FvNZmv3HJ2Nt0QYXqZojk3d9FJOLkwnuhzM9tmamh8d7HPM8QqjKH8DeHkFTx+CFlWpZZDA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "util": "^0.12.3"
       },
@@ -11383,7 +11430,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.0.tgz",
       "integrity": "sha512-EqPmREeOzttaLRm5HS7io98goBgZ7IVz79aDvqjD0kYXLtFZTc0T/U6wHTPKyIjb+MdN7DFIIX6hgdBEpWmfPA==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">= 8"
       }
@@ -11392,7 +11439,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/whatwg-encoding": {
       "version": "1.0.5",
@@ -11413,7 +11460,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -11438,7 +11485,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
       "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "is-bigint": "^1.0.1",
         "is-boolean-object": "^1.1.0",
@@ -11460,7 +11507,7 @@
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.7.tgz",
       "integrity": "sha512-vjxaB4nfDqwKI0ws7wZpxIlde1XrLX5uB0ZjpfshgmapJMD7jJWhZI+yToJTqaFByF0eNBcYxbjmCzoRP7CfEw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
@@ -13510,11 +13557,38 @@
         "fastq": "^1.6.0"
       }
     },
+    "@oslojs/binary": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@oslojs/binary/-/binary-0.2.0.tgz",
+      "integrity": "sha512-ubZRUsR675TzsccCQADGtPlKgNMCFkmhZ8FXgStxd5nMjrqNgVKhVtpKks6jCOap+U6Ny+yib8S/It2Cu8zVZQ=="
+    },
+    "@oslojs/crypto": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@oslojs/crypto/-/crypto-0.2.0.tgz",
+      "integrity": "sha512-C6kM0Yg2r0xWm7XoxAAdEaM/96yZbPRe8aCFfDenpl9VF3K3VOghRexrY4h812BRm3oRWesucBkYNlnliDv2LA==",
+      "requires": {
+        "@oslojs/binary": "0.2.0"
+      }
+    },
+    "@oslojs/encoding": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-0.2.0.tgz",
+      "integrity": "sha512-Z3AjpTFBsAiJBYl88fFRkjRWNgpu5PNqwWupfxyyqMFAoed+i2uIbMxQZr7AKhEy7ARclDxVRb/OkkBlO5qkhw=="
+    },
+    "@oslojs/oauth2": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@oslojs/oauth2/-/oauth2-0.1.0.tgz",
+      "integrity": "sha512-3pdqKcqRFCXLw6QyLrlsgDoEJGbjzj5WsBkqJfdyQhLFku6vZUK8TArhMQhtMPyCSKJiPWC3C5Ma98XphJY8uQ==",
+      "requires": {
+        "@oslojs/crypto": "0.2.0",
+        "@oslojs/encoding": "0.2.0"
+      }
+    },
     "@remix-run/node": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@remix-run/node/-/node-1.1.1.tgz",
       "integrity": "sha512-8WhpjiDqHb+RpsN95vygYrxyui/dWKi9ECJju+/xBuP8pODRKXU9hrCoxVC2FjFRhXUdErkCEDK/AZSDPAlqVw==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@remix-run/server-runtime": "1.1.1",
         "@types/busboy": "^0.3.1",
@@ -13533,7 +13607,7 @@
           "version": "0.7.3",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
           "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
-          "dev": true
+          "devOptional": true
         }
       }
     },
@@ -13639,7 +13713,7 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/@types/busboy/-/busboy-0.3.1.tgz",
       "integrity": "sha512-8BPLNy4x+7lbTOGkAyUIZrrPEZ7WzbO7YlVGMf9EZi9J9mqILEkYbt/kgVWQ7fizOISo1hM/7cAsWVTa7EhQDg==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@types/node": "*"
       }
@@ -13702,13 +13776,13 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.2.tgz",
       "integrity": "sha512-JepeIUPFDARgIs0zD/SKPgFsJEAF0X5/qO80llx59gOxFTboS9Amv3S+QfB7lqBId5sFXJ99BN0J6zFRvL9dDA==",
-      "dev": true
+      "devOptional": true
     },
     "@types/node-fetch": {
       "version": "2.5.12",
       "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.12.tgz",
       "integrity": "sha512-MKgC4dlq4kKNa/mYrwpKfzQMB5X3ee5U6fSprkKpToBqBmX4nFZL9cW5jl6sWn+xpRJ7ypWh2yyqqr8UUCstSw==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@types/node": "*",
         "form-data": "^3.0.0"
@@ -13718,7 +13792,7 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
           "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "asynckit": "^0.4.0",
             "combined-stream": "^1.0.8",
@@ -13909,7 +13983,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@web-std/blob/-/blob-3.0.1.tgz",
       "integrity": "sha512-opuhO8ZGGUj2jdFwfgMjWjVdKaHlQanGWXxj5wV2YQ1uGTuL/SADnsDitpMfRb+lSpmQyzpwZFfj4CNKQuwSKQ==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@web-std/stream": "1.0.0",
         "web-encoding": "1.1.5"
@@ -13919,7 +13993,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@web-std/file/-/file-3.0.0.tgz",
       "integrity": "sha512-ac2H3IUOky3GRJdbdJYgVvH+OApzpr0KX0t9p6Nj9AuHxKudc0pD7mVruekCW4CZv6DbOReDukwwskJN1bSCzA==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@web-std/blob": "^3.0.0"
       }
@@ -13928,7 +14002,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@web-std/stream/-/stream-1.0.0.tgz",
       "integrity": "sha512-jyIbdVl+0ZJyKGTV0Ohb9E6UnxP+t7ZzX4Do3AHjZKxUXKMs9EmqnBDQgHF7bEw0EzbQygOjtt/7gvtmi//iCQ==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "web-streams-polyfill": "^3.1.1"
       }
@@ -13950,7 +14024,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
       "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "event-target-shim": "^5.0.0"
       }
@@ -14094,7 +14168,7 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "devOptional": true
     },
     "atob": {
       "version": "2.1.2",
@@ -14106,7 +14180,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
       "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
-      "dev": true
+      "devOptional": true
     },
     "babel-jest": {
       "version": "26.6.3",
@@ -14305,13 +14379,13 @@
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
       "integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE=",
-      "dev": true
+      "devOptional": true
     },
     "blob-stream": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/blob-stream/-/blob-stream-0.1.3.tgz",
       "integrity": "sha1-mNZor2mW4PMu9mbQbiFczH13aGw=",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "blob": "0.0.4"
       }
@@ -14379,7 +14453,7 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.3.1.tgz",
       "integrity": "sha512-y7tTxhGKXcyBxRKAni+awqx8uqaJKrSFSNFSeRG5CsWNdmy2BIK+6VGWEW7TZnIO/533mtMEA4rOevQV815YJw==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "dicer": "0.3.0"
       }
@@ -14405,7 +14479,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
       "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
@@ -14608,7 +14682,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -14643,7 +14717,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.1.0.tgz",
       "integrity": "sha512-Alvs19Vgq07eunykd3Xy2jF0/qSNv2u7KDbAek9H5liV1UMijbqFs5cycZvv5dVsvseT/U4H8/7/w8Koh35C4A==",
-      "dev": true
+      "devOptional": true
     },
     "copy-descriptor": {
       "version": "0.1.1",
@@ -14807,7 +14881,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "object-keys": "^1.0.12"
       }
@@ -14826,7 +14900,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
+      "devOptional": true
     },
     "detect-newline": {
       "version": "3.1.0",
@@ -14838,7 +14912,7 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.3.0.tgz",
       "integrity": "sha512-MdceRRWqltEG2dZqO769g27N/3PXfcKl04VhYnBlo2YhH7zPi88VebsjTKclaOyiuMaGU72hTfw3VkUitGcVCA==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "streamsearch": "0.1.2"
       }
@@ -14930,7 +15004,7 @@
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
       "integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
@@ -14958,7 +15032,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
       "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
@@ -15458,7 +15532,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "dev": true
+      "devOptional": true
     },
     "exec-sh": {
       "version": "0.3.6",
@@ -15814,13 +15888,13 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
       "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
-      "dev": true
+      "devOptional": true
     },
     "form-data": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -15853,7 +15927,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "devOptional": true
     },
     "gensync": {
       "version": "1.0.0-beta.2",
@@ -15871,7 +15945,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
       "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -15897,7 +15971,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
       "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.1.1"
@@ -15975,7 +16049,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -15984,7 +16058,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
       "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
-      "dev": true
+      "devOptional": true
     },
     "has-flag": {
       "version": "3.0.0",
@@ -15996,13 +16070,13 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
       "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
-      "dev": true
+      "devOptional": true
     },
     "has-tostringtag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
       "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "has-symbols": "^1.0.2"
       }
@@ -16184,13 +16258,13 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "devOptional": true
     },
     "internal-slot": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
       "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "get-intrinsic": "^1.1.0",
         "has": "^1.0.3",
@@ -16210,7 +16284,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
       "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -16226,7 +16300,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
       "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "has-bigints": "^1.0.1"
       }
@@ -16235,7 +16309,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
       "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -16260,7 +16334,7 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
       "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
-      "dev": true
+      "devOptional": true
     },
     "is-ci": {
       "version": "2.0.0",
@@ -16301,7 +16375,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
       "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "has-tostringtag": "^1.0.0"
       }
@@ -16355,7 +16429,7 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
       "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "has-tostringtag": "^1.0.0"
       }
@@ -16373,7 +16447,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
       "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
-      "dev": true
+      "devOptional": true
     },
     "is-number": {
       "version": "7.0.0",
@@ -16385,7 +16459,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.6.tgz",
       "integrity": "sha512-bEVOqiRcvo3zO1+G2lVMy+gkkEm9Yh7cDMRusKKu5ZJKPUYSJwICTKZrNKHA2EbSP0Tu0+6B/emsYNHZyn6K8g==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "has-tostringtag": "^1.0.0"
       }
@@ -16415,7 +16489,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
       "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -16425,7 +16499,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz",
       "integrity": "sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA==",
-      "dev": true
+      "devOptional": true
     },
     "is-stream": {
       "version": "2.0.1",
@@ -16437,7 +16511,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
       "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "has-tostringtag": "^1.0.0"
       }
@@ -16446,7 +16520,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
       "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "has-symbols": "^1.0.2"
       }
@@ -16455,7 +16529,7 @@
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.8.tgz",
       "integrity": "sha512-HqH41TNZq2fgtGT8WHVFVJhBVGuY3AnP3Q36K8JKXUxSxRgk/d+7NjmwG2vo2mYmXK8UYZKu0qH8bVP5gEisjA==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
@@ -16474,7 +16548,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
       "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "call-bind": "^1.0.2"
       }
@@ -18043,13 +18117,13 @@
       "version": "1.51.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
       "integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==",
-      "dev": true
+      "devOptional": true
     },
     "mime-types": {
       "version": "2.1.34",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
       "integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "mime-db": "1.51.0"
       }
@@ -18131,7 +18205,7 @@
       "version": "2.6.6",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
       "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "whatwg-url": "^5.0.0"
       }
@@ -18288,13 +18362,13 @@
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
       "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
-      "dev": true
+      "devOptional": true
     },
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true
+      "devOptional": true
     },
     "object-visit": {
       "version": "1.0.1",
@@ -18309,7 +18383,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
       "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "call-bind": "^1.0.0",
         "define-properties": "^1.1.3",
@@ -18781,10 +18855,11 @@
       }
     },
     "remix-auth-oauth2": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/remix-auth-oauth2/-/remix-auth-oauth2-1.11.0.tgz",
-      "integrity": "sha512-Yf1LF6NLYPFa7X2Rax/VEhXmYXFjZOi/q+7DmbMeoMHjAfkpqxbvzqqYSKIKDGR51z5TXR5na4to4380mir5bg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/remix-auth-oauth2/-/remix-auth-oauth2-2.0.0.tgz",
+      "integrity": "sha512-VCSaOkFs9hxaSDvTsscthvH1ZLXKXokOmfDUQF+90faeWclcdqKd79V5FLieNxKON6AXQhJn+wBNY4TWTaAe1g==",
       "requires": {
+        "@oslojs/oauth2": "^0.1.0",
         "debug": "^4.3.4"
       }
     },
@@ -18895,7 +18970,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "devOptional": true
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -19228,7 +19303,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
       "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "call-bind": "^1.0.0",
         "get-intrinsic": "^1.0.2",
@@ -19598,7 +19673,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
       "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo=",
-      "dev": true
+      "devOptional": true
     },
     "string-length": {
       "version": "4.0.2",
@@ -19625,7 +19700,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
       "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
@@ -19635,7 +19710,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
       "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
@@ -19837,7 +19912,7 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
-      "dev": true
+      "devOptional": true
     },
     "ts-api-utils": {
       "version": "1.0.3",
@@ -19915,7 +19990,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
       "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "function-bind": "^1.1.1",
         "has-bigints": "^1.0.1",
@@ -20042,7 +20117,7 @@
       "version": "0.12.4",
       "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
       "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "inherits": "^2.0.3",
         "is-arguments": "^1.0.4",
@@ -20117,7 +20192,7 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.1.5.tgz",
       "integrity": "sha512-HYLeVCdJ0+lBYV2FvNZmv3HJ2Nt0QYXqZojk3d9FJOLkwnuhzM9tmamh8d7HPM8QqjKH8DeHkFTx+CFlWpZZDA==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@zxing/text-encoding": "0.9.0",
         "util": "^0.12.3"
@@ -20127,13 +20202,13 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.0.tgz",
       "integrity": "sha512-EqPmREeOzttaLRm5HS7io98goBgZ7IVz79aDvqjD0kYXLtFZTc0T/U6wHTPKyIjb+MdN7DFIIX6hgdBEpWmfPA==",
-      "dev": true
+      "devOptional": true
     },
     "webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
-      "dev": true
+      "devOptional": true
     },
     "whatwg-encoding": {
       "version": "1.0.5",
@@ -20154,7 +20229,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -20173,7 +20248,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
       "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "is-bigint": "^1.0.1",
         "is-boolean-object": "^1.1.0",
@@ -20192,7 +20267,7 @@
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.7.tgz",
       "integrity": "sha512-vjxaB4nfDqwKI0ws7wZpxIlde1XrLX5uB0ZjpfshgmapJMD7jJWhZI+yToJTqaFByF0eNBcYxbjmCzoRP7CfEw==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.1",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
+  "type": "module",
   "scripts": {
     "build": "tsc --project tsconfig.json",
     "prepare": "npm run build",
@@ -54,7 +55,7 @@
   },
   "dependencies": {
     "remix-auth": "^3.6.0",
-    "remix-auth-oauth2": "^1.11.0"
+    "remix-auth-oauth2": "^2.0.0"
   },
   "author": "Juhana Jauhiainen <juhana.jauhiainen@gmail.com>",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@speechmatics/remix-auth-microsoft",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,6 +107,13 @@ export class MicrosoftStrategy<User> extends OAuth2Strategy<
     return scope.join(MicrosoftStrategyScopeSeperator);
   }
 
+  protected authorizationParams(params: URLSearchParams): URLSearchParams {
+    // Passing the 'prompt' value is needed to get correct logout behaviour
+    // https://learn.microsoft.com/en-us/entra/identity-platform/v2-protocols-oidc#send-the-sign-in-request
+    if (this.prompt) params.set("prompt", this.prompt);
+    return params;
+  }
+
   protected async userProfile({
     access_token,
   }: TokenResponseBody): Promise<MicrosoftProfile> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,14 +107,6 @@ export class MicrosoftStrategy<User> extends OAuth2Strategy<
     return scope.join(MicrosoftStrategyScopeSeperator);
   }
 
-  protected authorizationParams(_params: URLSearchParams): URLSearchParams {
-    // TODO see what params are passed as arg here, might avoid needing the scope/prompt fields on this class
-    return new URLSearchParams({
-      scope: this.scope,
-      prompt: this.prompt,
-    });
-  }
-
   protected async userProfile({
     access_token,
   }: TokenResponseBody): Promise<MicrosoftProfile> {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,8 +2,8 @@
   "compilerOptions": {
     "lib": ["DOM", "DOM.Iterable", "ES2019"],
     "esModuleInterop": true,
-    "moduleResolution": "Node",
-    "module": "CommonJS",
+    "moduleResolution": "Bundler",
+    "module": "ESNext",
     "target": "ES2019",
     "strict": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Overview

This PR updates the dependency of `remix-auth-oauth2` to v2.0:
https://github.com/sergiodxa/remix-auth-oauth2/releases/tag/v2.0.0

The full changelog can be viewed above, but some important changes for our use case are:

- First-class support for OAuth2 refresh tokens, which will enable us to lengthen user sessions:
  https://github.com/sergiodxa/remix-auth-oauth2?tab=readme-ov-file#using-the-refresh-token
- Security improvement: Since the underlying OAuth2 strategy now relies on OsloJS, when fetching the `access_token`/`refresh_token`, it longer authenticates with the client secret in the URL string as it did before, instead making us choose to authenticate either with the request body, or with HTTP Basic Auth (diff here: https://github.com/sergiodxa/remix-auth-oauth2/compare/v1.11.0...v2.0.0#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L384) 
- Now that remix-auth-oauth2 only outputs ESM, this package has also been converted to an ES Module

## Implementation

Followed the updated [README.md in the upstream repo](https://github.com/sergiodxa/remix-auth-oauth2/blob/v2.0.0/README.md)

## Testing
Tested in our existing application on a separate branch with minimal changes. Automated testing could be implemented in a way similar to remix-auth-oauth2: https://github.com/sergiodxa/remix-auth-oauth2/tree/main/src/test
