### PR TITLE
fix: prompt should be optional to avoid interrupting SSO

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -65,7 +65,7 @@ export class MicrosoftStrategy<User> extends OAuth2Strategy<
   name = MicrosoftStrategyDefaultName;
   userInfoEndpoint: string;
   scope: string;
-  prompt: string;
+  prompt: string | undefined;
 
   constructor(
     {
@@ -92,7 +92,7 @@ export class MicrosoftStrategy<User> extends OAuth2Strategy<
 
     this.userInfoEndpoint = userInfoEndpoint;
     this.scope = this.getScope(options.scopes);
-    this.prompt = options.prompt ?? "none";
+    this.prompt = options.prompt;
   }
 
   //Allow users the option to pass a scope string, or typed array


### PR DESCRIPTION
`prompt` is an optional attribute. Defaulting to "none" prevents the default SSO flow from taking place if the user isn't logged in or hasn't authenticated the app.

See: https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-auth-code-flow


<img width="862" alt="Screenshot 2024-06-16 at 10 39 49 AM" src="https://github.com/speechmatics/remix-auth-microsoft/assets/7569921/e37ef00c-6177-401c-85b7-799a2e7381a0">

